### PR TITLE
Add useful missing interfaces

### DIFF
--- a/sdbus_async/bluez/__init__.py
+++ b/sdbus_async/bluez/__init__.py
@@ -30,7 +30,7 @@ from .gatt_api import (
 )
 from .media_api import MediaInterfaceAsync
 from .network_api import NetworkServerInterfaceAsync
-from .profile_api import ProfileManagerInterfaceAsync
+from .profile_api import ProfileInterfaceAsync, ProfileManagerInterfaceAsync
 
 __all__ = (
     'AdapterInterfaceAsync',
@@ -50,5 +50,6 @@ __all__ = (
 
     'NetworkServerInterfaceAsync',
 
+    'ProfileInterfaceAsync',
     'ProfileManagerInterfaceAsync',
 )

--- a/sdbus_async/bluez/agent_api.py
+++ b/sdbus_async/bluez/agent_api.py
@@ -61,7 +61,7 @@ class AgentInterfaceAsync(
     interface_name='org.bluez.Agent1',
 ):
     @dbus_method_async()
-    async def cancel(self):
+    async def cancel(self) -> None:
         raise NotImplementedError
 
     @dbus_method_async()

--- a/sdbus_async/bluez/agent_api.py
+++ b/sdbus_async/bluez/agent_api.py
@@ -65,17 +65,17 @@ class AgentInterfaceAsync(
         raise NotImplementedError
 
     @dbus_method_async()
-    async def release(self):
+    async def release(self) -> None:
         raise NotImplementedError
 
     @dbus_method_async(
         input_signature='os',
     )
-    async def authorize_service(self, device: str, uuid: str):
+    async def authorize_service(self, device: str, uuid: str) -> None:
         raise NotImplementedError
 
     @dbus_method_async(
         input_signature='o',
     )
-    async def request_authorization(self, device: str):
+    async def request_authorization(self, device: str) -> None:
         raise NotImplementedError

--- a/sdbus_async/bluez/agent_api.py
+++ b/sdbus_async/bluez/agent_api.py
@@ -54,3 +54,28 @@ class AgentManagerInterfaceAsync(
         agent_path: str,
     ) -> None:
         raise NotImplementedError
+
+
+class AgentInterfaceAsync(
+    DbusInterfaceCommonAsync,
+    interface_name='org.bluez.Agent1',
+):
+    @dbus_method_async()
+    def cancel(self):
+        raise NotImplementedError
+
+    @dbus_method_async()
+    def release(self):
+        raise NotImplementedError
+
+    @dbus_method_async(
+        input_signature='os',
+    )
+    def authorize_service(self, device: str, uuid: str):
+        raise NotImplementedError
+
+    @dbus_method_async(
+        input_signature='o',
+    )
+    def request_authorization(self, device: str):
+        raise NotImplementedError

--- a/sdbus_block/bluez/__init__.py
+++ b/sdbus_block/bluez/__init__.py
@@ -21,8 +21,12 @@ from __future__ import annotations
 
 from .adapter_api import AdapterInterface
 from .agent_api import AgentManagerInterface
+from .profile_api import ProfileInterface, ProfileManagerInterface
 
 __all__ = (
     'AdapterInterface',
     'AgentManagerInterface',
+
+    'ProfileInterface',
+    'ProfileManagerInterface',
 )

--- a/sdbus_block/bluez/__init__.py
+++ b/sdbus_block/bluez/__init__.py
@@ -18,3 +18,11 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 from __future__ import annotations
+
+from .adapter_api import AdapterInterface
+from .agent_api import AgentManagerInterface
+
+__all__ = (
+    'AdapterInterface',
+    'AgentManagerInterface',
+)

--- a/sdbus_block/bluez/adapter_api.py
+++ b/sdbus_block/bluez/adapter_api.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Copyright (C) 2022 igo95862
+
+# This file is part of python-sdbus
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from sdbus import (
+    DbusInterfaceCommon,
+    dbus_method,
+    dbus_property,
+)
+
+
+class AdapterInterface(
+    DbusInterfaceCommon,
+    interface_name='org.bluez.Adapter1',
+):
+    @dbus_method()
+    async def start_discovery(
+        self,
+    ) -> None:
+        raise NotImplementedError
+
+    @dbus_method()
+    async def stop_discovery(
+        self,
+    ) -> None:
+        raise NotImplementedError
+
+    @dbus_method(
+        input_signature='o',
+    )
+    async def remove_device(
+        self,
+        device_path: str,
+    ) -> None:
+        raise NotImplementedError
+
+    @dbus_method(
+        input_signature='a{sv}',
+    )
+    async def set_discovery_filter(
+        self,
+        properties: Dict[str, Tuple[str, Any]],
+    ) -> None:
+        raise NotImplementedError
+
+    @dbus_method(
+        result_signature='as',
+    )
+    async def get_discovery_filters(
+        self,
+    ) -> List[str]:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='s',
+    )
+    def address(self) -> str:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='s',
+    )
+    def address_type(self) -> str:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='s',
+    )
+    def name(self) -> str:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='s',
+    )
+    def alias(self) -> str:
+        raise NotImplementedError
+
+    @dbus_property(property_signature='u', property_name='Class')
+    def device_class(self) -> int:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='b',
+    )
+    def powered(self) -> bool:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='b',
+    )
+    def discoverable(self) -> bool:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='b',
+    )
+    def pairable(self) -> bool:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='u',
+    )
+    def pairable_timeout(self) -> int:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='u',
+    )
+    def discoverable_timeout(self) -> int:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='b',
+    )
+    def discovering(self) -> bool:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='as',
+        property_name='UUIDs',
+    )
+    def uuids(self) -> List[str]:
+        raise NotImplementedError
+
+    @dbus_property(
+        property_signature='s',
+    )
+    def modalias(self) -> str:
+        raise NotImplementedError
+
+    @dbus_property(property_signature='as')
+    def roles(self) -> List[str]:
+        raise NotImplementedError
+
+    @dbus_property(property_signature='as')
+    def experimental_features(self) -> List[str]:
+        raise NotImplementedError

--- a/sdbus_block/bluez/adapter_api.py
+++ b/sdbus_block/bluez/adapter_api.py
@@ -33,13 +33,13 @@ class AdapterInterface(
     interface_name='org.bluez.Adapter1',
 ):
     @dbus_method()
-    async def start_discovery(
+    def start_discovery(
         self,
     ) -> None:
         raise NotImplementedError
 
     @dbus_method()
-    async def stop_discovery(
+    def stop_discovery(
         self,
     ) -> None:
         raise NotImplementedError
@@ -47,7 +47,7 @@ class AdapterInterface(
     @dbus_method(
         input_signature='o',
     )
-    async def remove_device(
+    def remove_device(
         self,
         device_path: str,
     ) -> None:
@@ -56,7 +56,7 @@ class AdapterInterface(
     @dbus_method(
         input_signature='a{sv}',
     )
-    async def set_discovery_filter(
+    def set_discovery_filter(
         self,
         properties: Dict[str, Tuple[str, Any]],
     ) -> None:
@@ -65,7 +65,7 @@ class AdapterInterface(
     @dbus_method(
         result_signature='as',
     )
-    async def get_discovery_filters(
+    def get_discovery_filters(
         self,
     ) -> List[str]:
         raise NotImplementedError

--- a/sdbus_block/bluez/agent_api.py
+++ b/sdbus_block/bluez/agent_api.py
@@ -19,36 +19,40 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 from __future__ import annotations
 
-from .adapter_api import AdapterInterfaceAsync
-from .agent_api import AgentInterfaceAsync, AgentManagerInterfaceAsync
-from .battery_api import BatteryInterfaceAsync
-from .device_api import DeviceInterfaceAsync
-from .gatt_api import (
-    GattCharacteristicInterfaceAsync,
-    GattDescriptorInterfaceAsync,
-    GattServiceInterfaceAsync,
+from sdbus import (
+    DbusInterfaceCommon,
+    dbus_method,
 )
-from .media_api import MediaInterfaceAsync
-from .network_api import NetworkServerInterfaceAsync
-from .profile_api import ProfileManagerInterfaceAsync
 
-__all__ = (
-    'AdapterInterfaceAsync',
 
-    'AgentInterfaceAsync',
-    'AgentManagerInterfaceAsync',
+class AgentManagerInterface(
+    DbusInterfaceCommon,
+    interface_name='org.bluez.AgentManager1',
+):
+    @dbus_method(
+        input_signature='os',
+    )
+    async def register_agent(
+        self,
+        agent_path: str,
+        capability: str,
+    ) -> None:
+        raise NotImplementedError
 
-    'BatteryInterfaceAsync',
+    @dbus_method(
+        input_signature='o',
+    )
+    async def unregister_agent(
+        self,
+        agent_path: str,
+    ) -> None:
+        raise NotImplementedError
 
-    'DeviceInterfaceAsync',
-
-    'GattServiceInterfaceAsync',
-    'GattCharacteristicInterfaceAsync',
-    'GattDescriptorInterfaceAsync',
-
-    'MediaInterfaceAsync',
-
-    'NetworkServerInterfaceAsync',
-
-    'ProfileManagerInterfaceAsync',
-)
+    @dbus_method(
+        input_signature='o',
+    )
+    async def request_default_agent(
+        self,
+        agent_path: str,
+    ) -> None:
+        raise NotImplementedError

--- a/sdbus_block/bluez/agent_api.py
+++ b/sdbus_block/bluez/agent_api.py
@@ -32,7 +32,7 @@ class AgentManagerInterface(
     @dbus_method(
         input_signature='os',
     )
-    async def register_agent(
+    def register_agent(
         self,
         agent_path: str,
         capability: str,
@@ -42,7 +42,7 @@ class AgentManagerInterface(
     @dbus_method(
         input_signature='o',
     )
-    async def unregister_agent(
+    def unregister_agent(
         self,
         agent_path: str,
     ) -> None:
@@ -51,7 +51,7 @@ class AgentManagerInterface(
     @dbus_method(
         input_signature='o',
     )
-    async def request_default_agent(
+    def request_default_agent(
         self,
         agent_path: str,
     ) -> None:

--- a/sdbus_block/bluez/profile_api.py
+++ b/sdbus_block/bluez/profile_api.py
@@ -1,4 +1,3 @@
-
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # Copyright (C) 2022 igo95862
@@ -56,19 +55,17 @@ class ProfileInterface(
 ):
 
     @dbus_method()
-    def release(
-            self,
-    ) -> None:
+    def release(self) -> None:
         raise NotImplementedError
 
     @dbus_method(
         input_signature='oha{sv}',
     )
     def new_connection(
-            self,
-            device: str,
-            fd: int,
-            fd_properties: Dict[str, Tuple[str, Any]],
+        self,
+        device: str,
+        fd: int,
+        fd_properties: Dict[str, Tuple[str, Any]],
     ) -> None:
         raise NotImplementedError
 
@@ -76,7 +73,7 @@ class ProfileInterface(
         input_signature='o',
     )
     def request_disconnection(
-            self,
-            device: str,
+        self,
+        device: str,
     ) -> None:
         raise NotImplementedError

--- a/sdbus_block/bluez/profile_api.py
+++ b/sdbus_block/bluez/profile_api.py
@@ -1,3 +1,4 @@
+
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 # Copyright (C) 2022 igo95862
@@ -19,63 +20,63 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 from __future__ import annotations
 
-from sdbus import DbusInterfaceCommonAsync, dbus_method_async
+from typing import Any, Dict, Tuple
+
+from sdbus import DbusInterfaceCommonAsync, dbus_method
 
 
-class AgentManagerInterfaceAsync(
+class ProfileManagerInterface(
     DbusInterfaceCommonAsync,
-    interface_name='org.bluez.AgentManager1',
+    interface_name='org.bluez.ProfileManager1',
 ):
 
-    @dbus_method_async(
-        input_signature='os',
+    @dbus_method(
+        input_signature='osa{sv}',
     )
-    async def register_agent(
+    def register_profile(
         self,
-        agent_path: str,
-        capability: str,
+        profile_path: str,
+        uuid: str,
+        options: Dict[str, Tuple[str, Any]],
     ) -> None:
         raise NotImplementedError
 
-    @dbus_method_async(
+    @dbus_method(
         input_signature='o',
     )
-    async def unregister_agent(
+    def unregister_profile(
         self,
-        agent_path: str,
+        profile_path: str,
     ) -> None:
         raise NotImplementedError
 
-    @dbus_method_async(
-        input_signature='o',
-    )
-    async def request_default_agent(
-        self,
-        agent_path: str,
-    ) -> None:
-        raise NotImplementedError
-
-
-class AgentInterfaceAsync(
+class ProfileInterface(
     DbusInterfaceCommonAsync,
-    interface_name='org.bluez.Agent1',
+    interface_name='org.bluez.Profile1',
 ):
-    @dbus_method_async()
-    async def cancel(self):
+
+    @dbus_method()
+    def release(
+            self,
+    ) -> None:
         raise NotImplementedError
 
-    @dbus_method_async()
-    async def release(self):
-        raise NotImplementedError
-
-    @dbus_method_async(
-        input_signature='os',
+    @dbus_method(
+        input_signature='oha{sv}',
     )
-    async def authorize_service(self, device: str, uuid: str):
+    def new_connection(
+            self,
+            device: str,
+            fd: int,
+            fd_properties: Dict[str, Tuple[str, Any]],
+    ) -> None:
         raise NotImplementedError
 
-    @dbus_method_async(
+    @dbus_method(
         input_signature='o',
     )
-    async def request_authorization(self, device: str):
+    def request_disconnection(
+            self,
+            device: str,
+    ) -> None:
         raise NotImplementedError

--- a/sdbus_block/bluez/profile_api.py
+++ b/sdbus_block/bluez/profile_api.py
@@ -22,11 +22,11 @@ from __future__ import annotations
 
 from typing import Any, Dict, Tuple
 
-from sdbus import DbusInterfaceCommonAsync, dbus_method
+from sdbus import DbusInterfaceCommon, dbus_method
 
 
 class ProfileManagerInterface(
-    DbusInterfaceCommonAsync,
+    DbusInterfaceCommon,
     interface_name='org.bluez.ProfileManager1',
 ):
 
@@ -51,7 +51,7 @@ class ProfileManagerInterface(
         raise NotImplementedError
 
 class ProfileInterface(
-    DbusInterfaceCommonAsync,
+    DbusInterfaceCommon,
     interface_name='org.bluez.Profile1',
 ):
 


### PR DESCRIPTION
I'm working with this library to create an RFCOMM server. I'm adding missing interfaces as I'm needing them. Please let me know if there is a better way to create blocking and async interfaces than copying the code (though, that's what I've seen in [python-sdbus-networkmanager](https://github.com/python-sdbus/python-sdbus-networkmanager) as well).

I'll continue adding / editing until I have my application fully functional. So far I have:
- Added `ProfileInterfaceAsync` to default exports
- New async `AgentInterfaceAsync`
- New blocking `AdapterInterface`
- New blocking `AgentManagerInterface`
- New blocking `ProfileInterface`
- New blocking `ProfileManagerInterface`